### PR TITLE
Added spring data rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
 
 			<dependency>
 				<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/adminproject/admin/DAO/CourseRepositoryV2.java
+++ b/src/main/java/com/adminproject/admin/DAO/CourseRepositoryV2.java
@@ -1,0 +1,14 @@
+package com.adminproject.admin.DAO;
+
+import com.adminproject.admin.Entities.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface CourseRepositoryV2 extends JpaRepository<Course, Long> {
+
+}

--- a/src/main/java/com/adminproject/admin/Web/CourseRestController.java
+++ b/src/main/java/com/adminproject/admin/Web/CourseRestController.java
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
-@RestController
-@RequestMapping("/courses")
+//@RestController
+//@RequestMapping("/courses")
 public class CourseRestController {
 
     @Autowired


### PR DESCRIPTION
This change contains an example of a spring data source implementation, using the pre-existing course entity,
I started first by adding the spring data source dependency:
<dependency>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-starter-data-rest</artifactId>
</dependency>

Then I disabled the existing "/courses" path.. so that I can use it.
Lastly I have added a new CourseRepository.

Now you can just go to the url: "/courses", "/courses/{id}",.. the controller methods are already implemented (just follow the conventions https://restfulapi.net/resource-naming/) 